### PR TITLE
docs: fix simple typo, termniated -> terminated

### DIFF
--- a/vedis_intro.c
+++ b/vedis_intro.c
@@ -59,7 +59,7 @@ static void Fatal(vedis *pStore,const char *zMsg)
 		vedis_config(pStore,VEDIS_CONFIG_ERR_LOG,&zErr,&iLen);
 		if( iLen > 0 ){
 			/* Output the error log */
-			puts(zErr); /* Always null termniated */
+			puts(zErr); /* Always null terminated */
 		}
 	}else{
 		if( zMsg ){


### PR DESCRIPTION
There is a small typo in vedis_intro.c.

Should read `terminated` rather than `termniated`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md